### PR TITLE
cleanup

### DIFF
--- a/include/libKitsuneProjectCommon/network_session/session.h
+++ b/include/libKitsuneProjectCommon/network_session/session.h
@@ -67,10 +67,14 @@ public:
     };
 
 private:
-    friend SessionHandler;
-    friend SessionController;
     friend InternalSessionInterface;
 
+    Kitsune::Common::Statemachine m_statemachine;
+    Network::AbstractSocket* m_socket = nullptr;
+    uint32_t m_sessionId = 0;
+    bool m_sessionReady = true;
+
+    // internal methods triggered by the InternalSessionInterface
     bool connectiSession(const uint32_t sessionId,
                          const bool init = false);
     bool makeSessionReady();
@@ -81,11 +85,6 @@ private:
 
     bool sendHeartbeat();
     void initStatemachine();
-
-    Kitsune::Common::Statemachine m_statemachine;
-    Network::AbstractSocket* m_socket = nullptr;
-    uint32_t m_sessionId = 0;
-    bool m_sessionReady = true;
 
     // callbacks
     void* m_sessionTarget = nullptr;

--- a/src/network_session/internal_session_interface.cpp
+++ b/src/network_session/internal_session_interface.cpp
@@ -36,9 +36,22 @@ namespace Project
 namespace Common
 {
 
-InternalSessionInterface::InternalSessionInterface()
+InternalSessionInterface::InternalSessionInterface(void* sessionTarget,
+                                                   void (*processSession)(void*, Session*),
+                                                   void* dataTarget,
+                                                   void (*processData)(void*, Session*,
+                                                                       void*, const uint64_t),
+                                                   void* errorTarget,
+                                                   void (*processError)(void*, Session*,
+                                                                        const uint8_t,
+                                                                        const std::string))
 {
-
+    m_sessionTarget = sessionTarget;
+    m_processSession = processSession;
+    m_dataTarget = dataTarget;
+    m_processData = processData;
+    m_errorTarget = errorTarget;
+    m_processError = processError;
 }
 
 /**
@@ -93,6 +106,16 @@ InternalSessionInterface::sendMessage(Session* session,
 }
 
 /**
+ * @brief InternalSessionInterface::sendHeartbeat
+ * @param session
+ */
+void
+InternalSessionInterface::sendHeartbeat(Session *session)
+{
+    session->sendHeartbeat();
+}
+
+/**
  * @brief RessourceHandler::connectiSession
  * @param session
  * @param sessionId
@@ -104,6 +127,13 @@ InternalSessionInterface::connectiSession(Session* session,
                                           const uint32_t sessionId,
                                           const bool init)
 {
+    session->m_sessionTarget = m_sessionTarget;
+    session->m_processSession = m_processSession;
+    session->m_dataTarget = m_dataTarget;
+    session->m_processData = m_processData;
+    session->m_errorTarget = m_errorTarget;
+    session->m_processError = m_processError;
+
     return session->connectiSession(sessionId, init);
 }
 

--- a/src/network_session/internal_session_interface.h
+++ b/src/network_session/internal_session_interface.h
@@ -42,13 +42,21 @@ class Session;
 class InternalSessionInterface
 {
 public:
-    InternalSessionInterface();
+    InternalSessionInterface(void* sessionTarget,
+                             void (*processSession)(void*, Session*),
+                             void* dataTarget,
+                             void (*processData)(void*, Session*,
+                                                 void*, const uint64_t),
+                             void* errorTarget,
+                             void (*processError)(void*, Session*,
+                                                  const uint8_t, const std::string));
 
     // callback-forwarding
     void receivedData(Session* session, void* data, const uint64_t dataSize);
     void receivedError(Session* session, const uint8_t errorCode, const std::string message);
 
     bool sendMessage(Session* session, const void* data, const uint32_t size);
+    void sendHeartbeat(Session* session);
 
     bool connectiSession(Session* session,
                          const uint32_t sessionId,
@@ -60,6 +68,17 @@ public:
                     const bool init = false,
                     const bool replyExpected = false);
     bool disconnectSession(Session* session);
+
+private:
+
+    // callbacks
+    void* m_sessionTarget = nullptr;
+    void (*m_processSession)(void*, Session*);
+    void* m_dataTarget = nullptr;
+    void (*m_processData)(void*, Session*, void*, const uint64_t);
+    void* m_errorTarget = nullptr;
+    void (*m_processError)(void*, Session*, const uint8_t, const std::string);
+
 };
 
 } // namespace Common

--- a/src/network_session/session_constroller.cpp
+++ b/src/network_session/session_constroller.cpp
@@ -192,12 +192,11 @@ SessionController::startUnixDomainSession(const std::string socketFile)
 {
     Network::UnixDomainSocket* unixDomainSocket = new Network::UnixDomainSocket(socketFile);
     Session* newSession = new Session(unixDomainSocket);
-
     unixDomainSocket->setMessageCallback(newSession, &processMessageUnixDomain);
-    newSession->m_sessionId = SessionHandler::m_sessionHandler->increaseSessionIdCounter();
 
-    SessionHandler::m_sessionHandler->addSession(newSession->m_sessionId, newSession);
-    newSession->connectiSession(newSession->m_sessionId, true);
+    const uint32_t newId = SessionHandler::m_sessionHandler->increaseSessionIdCounter();
+    SessionHandler::m_sessionHandler->addSession(newId, newSession);
+    SessionHandler::m_sessionInterface->connectiSession(newSession, newId, true);
 }
 
 /**
@@ -211,12 +210,11 @@ SessionController::startTcpSession(const std::string address,
 {
     Network::TcpSocket* tcpSocket = new Network::TcpSocket(address, port);
     Session* newSession = new Session(tcpSocket);
-
     tcpSocket->setMessageCallback(newSession, &processMessageTcp);
-    newSession->m_sessionId = SessionHandler::m_sessionHandler->increaseSessionIdCounter();
 
-    SessionHandler::m_sessionHandler->addSession(newSession->m_sessionId, newSession);
-    newSession->connectiSession(newSession->m_sessionId, true);
+    const uint32_t newId = SessionHandler::m_sessionHandler->increaseSessionIdCounter();
+    SessionHandler::m_sessionHandler->addSession(newId, newSession);
+    SessionHandler::m_sessionInterface->connectiSession(newSession, newId, true);
 }
 
 /**
@@ -237,12 +235,11 @@ SessionController::startTlsTcpSession(const std::string address,
                                                                     certFile,
                                                                     keyFile);
     Session* newSession = new Session(tlsTcpSocket);
-
     tlsTcpSocket->setMessageCallback(newSession, &processMessageTlsTcp);
-    newSession->m_sessionId = SessionHandler::m_sessionHandler->increaseSessionIdCounter();
 
-    SessionHandler::m_sessionHandler->addSession(newSession->m_sessionId, newSession);
-    newSession->connectiSession(newSession->m_sessionId, true);
+    const uint32_t newId = SessionHandler::m_sessionHandler->increaseSessionIdCounter();
+    SessionHandler::m_sessionHandler->addSession(newId, newSession);
+    SessionHandler::m_sessionInterface->connectiSession(newSession, newId, true);
 }
 
 /**

--- a/src/network_session/session_handler.h
+++ b/src/network_session/session_handler.h
@@ -68,14 +68,6 @@ public:
     uint16_t increaseSessionIdCounter();
     uint32_t m_serverIdCounter = 0;
 
-    // callbacks
-    void* m_sessionTarget = nullptr;
-    void (*m_processSession)(void*, Session*);
-    void* m_dataTarget = nullptr;
-    void (*m_processData)(void*, Session*, void*, const uint64_t);
-    void* m_errorTarget = nullptr;
-    void (*m_processError)(void*, Session*, const uint8_t, const std::string);
-
     // object-holder
     std::atomic_flag m_sessionMap_lock = ATOMIC_FLAG_INIT;
     std::map<uint32_t, Session*> m_sessions;


### PR DESCRIPTION
made InternalSessionInterface the only class, which is allowed to call the
private methods of the session-class.