### PR TITLE
Change: use current version of libKitsunemimiNetwork, which uses templates now

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -52,9 +52,9 @@ function get_required_kitsune_lib_repo () {
 
 #-----------------------------------------------------------------------------------------------------------------
 
-get_required_kitsune_lib_repo "libKitsunemimiCommon" "v0.25.3" 4 "staticlib"
+get_required_kitsune_lib_repo "libKitsunemimiCommon" "v0.27.0" 4 "staticlib"
 
-get_required_kitsune_lib_repo "libKitsunemimiNetwork" "v0.8.2" 4 "staticlib"
+get_required_kitsune_lib_repo "libKitsunemimiNetwork" "develop" 4 "staticlib"
 
 #-----------------------------------------------------------------------------------------------------------------
 

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -357,7 +357,7 @@ Session::connectiSession(const uint32_t sessionId,
         }
 
         // connect socket
-        if(m_socket->initClientSide(error) == false)
+        if(m_socket->initConnection(error) == false)
         {
             m_initState = -1;
             return false;


### PR DESCRIPTION
## Description

Change: use current version of libKitsunemimiNetwork, which uses templates now

## Related Issues

- #167 

## How it was tested?

- ci-pipeline